### PR TITLE
Mark legacy components as archived

### DIFF
--- a/ARCHIVED_COMPONENTS.md
+++ b/ARCHIVED_COMPONENTS.md
@@ -1,0 +1,8 @@
+# Archived Components
+
+The following directories are retained for historical reference but are no longer actively maintained:
+
+- [software/libs/open-qm-core](software/libs/open-qm-core)
+- [software/libs/open-qm-moduleDriver](software/libs/open-qm-moduleDriver)
+
+These components may be removed in the future.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ We are very much in development still, so check back often! We are also acceptin
 
  - For a quick start running on your own computer, check out [Single Host Deployment](deployment/Single%20Host)
  - To see all the ways you can deploy OQM for yourself, see [Deployment](deployment/)
+  - Archived components: [open-qm-core](software/libs/open-qm-core) and [open-qm-moduleDriver](software/libs/open-qm-moduleDriver). See [ARCHIVED_COMPONENTS.md](ARCHIVED_COMPONENTS.md) for details.
 
 ## How it works
 

--- a/software/libs/README.md
+++ b/software/libs/README.md
@@ -4,4 +4,5 @@
 
 This is where common libraries exist for OpenQuarterMaster.
 
-- For the Core library, see [open-qm-core](open-qm-core)
+- For the Core library, see [open-qm-core](open-qm-core) (archived)
+- The module driver library [open-qm-moduleDriver](open-qm-moduleDriver) is archived

--- a/software/libs/open-qm-core/README.md
+++ b/software/libs/open-qm-core/README.md
@@ -1,8 +1,5 @@
-# Open QuarterMaster Core Library
-
-THIS PARTICULAR PROJECT IS DEAD
-
-It is slated for removal. It is only here as a reference until we finish a couple of other small tasks. Please ignore this project
+# Open QuarterMaster Core Library (Archived)
+This component has been archived and is no longer maintained. It remains for reference only and may be removed in the future.
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/tech.epic-breakfast-productions.openQuarterMaster.lib/open-qm-lib-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/tech.epic-breakfast-productions.openQuarterMaster.lib/open-qm-lib-core)
 

--- a/software/libs/open-qm-moduleDriver/README.md
+++ b/software/libs/open-qm-moduleDriver/README.md
@@ -1,9 +1,5 @@
-# Open QuarterMaster Core Library
-
-
-THIS PARTICULAR PROJECT IS DEAD
-
-It is slated for removal. It is only here as a reference until we finish a couple of other small tasks. Please ignore this project
+# Open QuarterMaster Module Driver Library (Archived)
+This library is archived and no longer maintained. It is kept for reference only and may be removed in the future.
 
 
 ## TODOS:


### PR DESCRIPTION
## Summary
- note archived libraries in root README and link to ARCHIVED_COMPONENTS.md
- list archived modules in software libs README
- clarify that open-qm-core and open-qm-moduleDriver libraries are archived
- add ARCHIVED_COMPONENTS.md listing deprecated directories

## Testing
- `./software/libs/open-qm-core/gradlew -p software/libs/open-qm-core tasks` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_6848ea69ad388332b0905dd8dad7b057