### PR TITLE
Fix #1044: Fix broken image upload form in category selection

### DIFF
--- a/software/core/oqm-core-base-station/src/main/resources/META-INF/resources/res/js/obj/media/imageAddFromSelect.js
+++ b/software/core/oqm-core-base-station/src/main/resources/META-INF/resources/res/js/obj/media/imageAddFromSelect.js
@@ -1,16 +1,14 @@
 
 const ImageAddFromSelect = {
-	formMessages: $("addImageFormMessages"),
+	formMessages: $("#addImageFormMessages"),
 	imageSearchSelectModalLabelCloseButton: $("#imageSearchSelectModalLabelCloseButton"),
 	imageAddImageForm: $("#addImageForm"),
-	imageAddTitleInput: $("#addTitleInput"),
 	imageAddDescriptionInput: $("#addDescriptionInput"),
 	imageUploadInput: $("#imageUploadInput"),
 	imageAddKeywordInputDiv: $("#addImageForm").find(".keywordInputDiv"),
 	imageAddAttInputDiv: $("#addImageForm").find(".attInputDiv"),
 	resetImageAdd(){
 		ImageAddFromSelect.imageAddImageForm.trigger("reset");
-		ImageAddFromSelect.imageAddTitleInput.text("");
 		ImageAddFromSelect.imageAddDescriptionInput.html("");
 		ImageAddFromSelect.imageUploadInput.html("");
 		ImageAddFromSelect.imageAddKeywordInputDiv.html("");
@@ -43,7 +41,8 @@ ImageAddFromSelect.imageAddImageForm.submit(function (ev) {
 			async: false,
 			done: function(data) {
 				console.log("New image id: " + data.id)
-				ImageSearchSelect.selectImage(addData.title, data.id);
+				let fileName = ImageAddFromSelect.imageUploadInput[0].files[0].name;
+				ImageSearchSelect.selectImage(fileName, data.id);
 				ImageAddFromSelect.imageSearchSelectModalLabelCloseButton.click();
 				ImageAddFromSelect.resetImageAdd();
 			},


### PR DESCRIPTION
## Summary
- Fixes jQuery selector missing # prefix: $("addImageFormMessages") -> $("#addImageFormMessages")
- Removes reference to non-existent addTitleInput element
- Uses filename as title instead of undefined addData.title

## Test plan
- [ ] Open item category form and attempt to upload an image
- [ ] Image upload should work without JavaScript errors
- [ ] Manual testing required (Base Station UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)