### PR TITLE
Dev/1377 fr deployment snh station captain make utilities for ram usage limits

### DIFF
--- a/deployment/Single Host/Station-Captain/.idea/Station-Captain.iml
+++ b/deployment/Single Host/Station-Captain/.idea/Station-Captain.iml
@@ -10,7 +10,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/installerBuild" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="/usr/bin/python3" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Python 3.10 interpreter library" level="application" />
   </component>

--- a/deployment/Single Host/Station-Captain/properties.json
+++ b/deployment/Single Host/Station-Captain/properties.json
@@ -1,6 +1,6 @@
 {
 	"packageName":"oqm-manager-station+captain",
-	"version":"2.12.3",
+	"version":"2.13.0-SNAPSHOT",
 	"description":"Utility for setting up and maintaining an instance of Open QuarterMaster.",
 	"maintainer": {
 		"name":"EBP"

--- a/deployment/Single Host/Station-Captain/src/lib/OtherUtils.py
+++ b/deployment/Single Host/Station-Captain/src/lib/OtherUtils.py
@@ -88,6 +88,13 @@ class OtherUtils:
 		return number / cls._gbConversionFactor
 
 	@classmethod
+	def __normalizeMinMaxInput(cls, mm)->float:
+		try:
+			return float(mm)
+		except ValueError:
+			return float(mainCM.getConfigVal(mm))
+
+	@classmethod
 	def service_ram_limit(
 		cls,
 		min: float | str | None = None,
@@ -99,6 +106,10 @@ class OtherUtils:
 		:return:
 		"""
 		numOqmServices = ServiceUtils.getNumOqmServices()
+
+		if numOqmServices == 0:
+			numOqmServices = 1
+
 		profileLimitFraction = RamLimitProfile.get_profile_fraction()
 		hostRamB = psutil.virtual_memory().total
 
@@ -116,14 +127,12 @@ class OtherUtils:
 		calculated = cls.__BtoGB(fairShareB)
 
 		if min is not None:
-			if isinstance(min, str):
-				min = float(mainCM.getConfigVal(min))
+			min = cls.__normalizeMinMaxInput(min)
 
 			if calculated < min:
 				calculated = min
 		if max is not None:
-			if isinstance(max, str):
-				max = float(mainCM.getConfigVal(max))
+			max = cls.__normalizeMinMaxInput(max)
 
 			if calculated > max:
 				calculated = max

--- a/deployment/Single Host/Station-Captain/src/lib/OtherUtils.py
+++ b/deployment/Single Host/Station-Captain/src/lib/OtherUtils.py
@@ -1,22 +1,131 @@
 import os
 import shutil
-from ConfigManager import *
-from ServiceUtils import *
+import psutil
 import docker
 from LogUtils import *
+from ConfigManager import *
+from ServiceUtils import *
+
+
+class RamLimitProfile(Enum):
+	"""
+	Allocation profile.
+
+	slim        – conservative; reserves a larger share of host RAM for
+				  the OS and any non-managed services.  Per-container
+				  limits skew toward the *minimum*.
+
+	performance – generous; allows containers to claim most of the
+				  host RAM.  Per-container limits skew toward the
+				  *maximum*.
+	"""
+	SLIM = "slim"
+	PERFORMANCE = "performance"
+
+	@classmethod
+	def get_profile(cls) -> 'RamLimitProfile':
+		return RamLimitProfile[mainCM.getConfigVal("system.resources.ramLimitProfile")]
+
+	@classmethod
+	def get_profile_fraction(cls, profile: 'RamLimitProfile' = None) -> float:
+		if profile is None:
+			profile = cls.get_profile()
+
+		if profile == RamLimitProfile.SLIM:
+			return 0.6
+		if profile == RamLimitProfile.PERFORMANCE:
+			return 0.8
+		raise ValueError("Unknown profile " + str(profile))
 
 
 class OtherUtils:
-    log = LogUtils.setupLogger("OtherUtils")
+	log = LogUtils.setupLogger("OtherUtils")
+	_gbConversionFactor = 1024 * 1024 * 1024
 
-    @staticmethod
-    def human_size(numBytes: int, units=None):
-        """
-        Returns a human readable string representation of bytes
-        https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
-        """
-        if units is None:
-            units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']
-        if not units:
-            return f"{numBytes}B"
-        return str(numBytes) + units[0] if numBytes < 1024 else OtherUtils.human_size(numBytes >> 10, units[1:])
+	@classmethod
+	def setupArgParser(cls, subparsers):
+		utilsSubparser = subparsers.add_parser("utils", aliases=["u"], help="Commands for miscellaneous utilities")
+		snapshotSubparsers = utilsSubparser.add_subparsers(dest="containerCommand")
+
+		snapshot_parser = snapshotSubparsers.add_parser("calcRamLimit", help="Calculates an appropriate RAM limit based on the system for a service.")
+		snapshot_parser.add_argument(
+			"--min",
+			dest="min", default=None, help="The minimum amount of ram to set as a limit, in Gigabytes"
+		)
+		snapshot_parser.add_argument(
+			"--max",
+			 dest="max", default=None, help="The maximum amount of ram to set as a limit, in Gigabytes"
+		)
+		snapshot_parser.set_defaults(func=cls.serviceRamLimitFromArgs)
+
+	@classmethod
+	def serviceRamLimitFromArgs(cls, args):
+		success, output = cls.service_ram_limit(min=args.min, max=args.max)
+
+		if success:
+			print(format(output, '.3f')+ "G")
+		else:
+			print("FAILED to calculate RAM limit: " + output, file=sys.stderr)
+
+	@staticmethod
+	def human_size(numBytes: int, units=None):
+		"""
+		Returns a human readable string representation of bytes
+		https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
+		"""
+		if units is None:
+			units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']
+		if not units:
+			return f"{numBytes}B"
+		return str(numBytes) + units[0] if numBytes < 1024 else OtherUtils.human_size(numBytes >> 10, units[1:])
+
+	@classmethod
+	def __GBtoB(cls, number: int) -> int:
+		return number * cls._gbConversionFactor
+
+	@classmethod
+	def __BtoGB(cls, number: int) -> int:
+		return number / cls._gbConversionFactor
+
+	@classmethod
+	def service_ram_limit(
+		cls,
+		min: float | str | None = None,
+		max: float | str | None = None
+	) -> float:
+		"""
+		:param min: the minimum amount of ram to set as a limit, in Gigabytes
+		:param max: the maximum amount of ram to set as a limit, in Gigabytes
+		:return:
+		"""
+		numOqmServices = ServiceUtils.getNumOqmServices()
+		profileLimitFraction = RamLimitProfile.get_profile_fraction()
+		hostRamB = psutil.virtual_memory().total
+
+		cls.log.info("Service ram calculation numbers: \n\t"
+				+ "Min ram to give: " + str(min) + "\n\t"
+				+ "Max ram to give: " + str(max) + "\n\t"
+				+ "Num OQM services: " + str(numOqmServices) + "\n\t"
+				+ "Set profile limit fraction: " + str(profileLimitFraction) + "\n\t"
+				+ "Host ram: " + str(hostRamB) + " / " + str(cls.__BtoGB(hostRamB))
+				)
+
+		oqmSystemLimit = hostRamB * profileLimitFraction
+		fairShareB = oqmSystemLimit / numOqmServices
+
+		calculated = cls.__BtoGB(fairShareB)
+
+		if min is not None:
+			if isinstance(min, str):
+				min = float(mainCM.getConfigVal(min))
+
+			if calculated < min:
+				calculated = min
+		if max is not None:
+			if isinstance(max, str):
+				max = float(mainCM.getConfigVal(max))
+
+			if calculated > max:
+				calculated = max
+
+		return True, calculated

--- a/deployment/Single Host/Station-Captain/src/lib/ServiceUtils.py
+++ b/deployment/Single Host/Station-Captain/src/lib/ServiceUtils.py
@@ -7,55 +7,58 @@ from LogUtils import *
 
 
 class ServiceStateCommand(Enum):
-    start = 1,
-    stop = 2,
-    restart = 3
+	start = 1,
+	stop = 2,
+	restart = 3
 
 
 class ServiceUtils:
-    """
+	"""
 
-    """
-    log = LogUtils.setupLogger("ServiceUtils")
-    SERVICE_ALL_INFRA = "oqm-infra-*"
-    SERVICE_ALL_CORE = "oqm-core-*"
-    SERVICE_ALL = "oqm-*"
+	"""
+	log = LogUtils.setupLogger("ServiceUtils")
+	SERVICE_ALL_INFRA = "oqm-infra-*"
+	SERVICE_ALL_CORE = "oqm-core-*"
+	SERVICE_ALL = "oqm-*"
 
-    @staticmethod
-    def doServiceCommand(command: ServiceStateCommand, service: str) -> bool:
-        ServiceUtils.log.info("Performing %s command on service %s", command, service)
-        args = ["systemctl", command.name, service]
-        if "*" in service:
-            args.append("--all")
-        result = subprocess.run(args, shell=False, capture_output=True, text=True, check=False)
+	@staticmethod
+	def doServiceCommand(command: ServiceStateCommand, service: str) -> bool:
+		ServiceUtils.log.info("Performing %s command on service %s", command, service)
+		args = ["systemctl", command.name, service]
+		if "*" in service:
+			args.append("--all")
+		result = subprocess.run(args, shell=False, capture_output=True, text=True, check=False)
 
-        if result.returncode != 0:
-            ServiceUtils.log.warning("Command was unsuccessful. Error code: " + str(result.returncode))
-            ServiceUtils.log.debug("Erring command stdout: " + result.stdout)
-            ServiceUtils.log.debug("Erring command stderr: " + result.stderr)
-            return False
-        ServiceUtils.log.info("%s Command was successful on %s", command, service)
-        return True
+		if result.returncode != 0:
+			ServiceUtils.log.warning("Command was unsuccessful. Error code: " + str(result.returncode))
+			ServiceUtils.log.debug("Erring command stdout: " + result.stdout)
+			ServiceUtils.log.debug("Erring command stderr: " + result.stderr)
+			return False
+		ServiceUtils.log.info("%s Command was successful on %s", command, service)
+		return True
 
-    @staticmethod
-    def getServiceNames(serviceFilter: str = SERVICE_ALL) -> (bool, [str]):
-        ServiceUtils.log.info("Getting service names based on filter: %s", serviceFilter)
-        result = subprocess.run(["systemctl", "list-units", "--no-legend", "--all", serviceFilter], shell=False, capture_output=True, text=True, check=False)
+	@staticmethod
+	def getServiceNames(serviceFilter: str = SERVICE_ALL) -> (bool, [str]):
+		ServiceUtils.log.info("Getting service names based on filter: %s", serviceFilter)
+		result = subprocess.run(["systemctl", "list-units", "--no-legend", "--all", serviceFilter], shell=False, capture_output=True, text=True, check=False)
 
-        if result.returncode != 0:
-            ServiceUtils.log.warning("Command was unsuccessful. Error code: {0}", result.returncode)
-            ServiceUtils.log.debug("Erring command stderr: {0}", result.stderr)
-            return False, result.stderr
+		if result.returncode != 0:
+			ServiceUtils.log.warning("Command was unsuccessful. Error code: {0}", result.returncode)
+			ServiceUtils.log.debug("Erring command stderr: {0}", result.stderr)
+			return False, result.stderr
 
-        output = []
-        for curRawService in re.split(r'\n', result.stdout):
-            curService = re.split(r' ', curRawService[2:])[0].strip()
-            if len(curService):
-                output.append(curService)
-        ServiceUtils.log.debug("Got OQM services: %s", output)
+		output = []
+		for curRawService in re.split(r'\n', result.stdout):
+			curService = re.split(r' ', curRawService[2:])[0].strip()
+			if len(curService):
+				output.append(curService)
+		ServiceUtils.log.debug("Got OQM services: %s", output)
 
-        return True, output
+		return True, output
 
-    # -q
-    # --no-legend
-    #
+	@classmethod
+	def getNumOqmServices(cls) -> int:
+		success, services = cls.getServiceNames()
+		if success:
+			return len(services)
+		return 0

--- a/deployment/Single Host/Station-Captain/src/mainConfig.json
+++ b/deployment/Single Host/Station-Captain/src/mainConfig.json
@@ -10,6 +10,9 @@
 			"type": "core",
 			"name": "base-station",
 			"path": "/"
+		},
+		"resources": {
+			"ramLimitProfile": "SLIM"
 		}
 	},
 	"captain": {

--- a/deployment/Single Host/Station-Captain/src/oqm-captain.py
+++ b/deployment/Single Host/Station-Captain/src/oqm-captain.py
@@ -15,6 +15,7 @@ from LogManagement import *
 from CertsUtils import *
 from RegistrationUtils import *
 from DemoModeUtils import *
+from OtherUtils import *
 import argparse
 import atexit
 import argcomplete
@@ -57,6 +58,7 @@ LogManagement.setupArgParser(subparsers)
 CertsUtils.setupArgParser(subparsers)
 RegistrationUtils.setupArgParser(subparsers)
 DemoModeUtils.setupArgParser(subparsers)
+OtherUtils.setupArgParser(subparsers)
 
 # TODO:: subscription utility
 # TODO:: plugin utilities

--- a/software/core/oqm-core-characteristics/installerSrc/20-core-characteristics.json
+++ b/software/core/oqm-core-characteristics/installerSrc/20-core-characteristics.json
@@ -21,7 +21,13 @@
 					"backgroundColor": " "
 				}
 			},
-			"errorPage": "/serviceErr/errPage.html"
+			"errorPage": "/serviceErr/errPage.html",
+			"resourceLimits": {
+				"mem": {
+					"min": 0.05,
+					"max": 0.512
+				}
+			}
 		}
 	}
 }

--- a/software/core/oqm-core-characteristics/installerSrc/installerProperties.json
+++ b/software/core/oqm-core-characteristics/installerSrc/installerProperties.json
@@ -7,7 +7,7 @@
 	"description": "Characteristics instance for Open QuarterMaster.",
 	"homepage": "https://github.com/Epic-Breakfast-Productions/OpenQuarterMaster/tree/main/software/core/oqm-core-characteristics",
 	"dependencies": {
-		"deb": "curl, jq, docker.io, oqm-manager-station+captain (>= 2.11.0), oqm-infra-homepage",
+		"deb": "curl, jq, docker.io, oqm-manager-station+captain (>= 2.13.0), oqm-infra-homepage",
 		"debRec": ""
 	},
 	"copyright": {

--- a/software/core/oqm-core-characteristics/installerSrc/oqm-core-characteristics.service
+++ b/software/core/oqm-core-characteristics/installerSrc/oqm-core-characteristics.service
@@ -21,7 +21,6 @@ Environment="ENV_CONFIG_TEMPLATE=/etc/oqm/serviceConfig/core/characteristics/cor
 Environment="ENV_CONFIG_FILE=/tmp/oqm/serviceConfig/core/characteristics/env.list"
 Environment="USER_CONFIG_TEMPLATE=/etc/oqm/serviceConfig/core/characteristics/user-config.list"
 Environment="USER_CONFIG_FILE=/tmp/oqm/serviceConfig/core/characteristics/user.list"
-Environment="MEMORY_LIMIT=$(oqm-captain u calcRamLimit)"
 
 ExecStartPre=/bin/bash -c "oqm-captain container ensure-setup"
 

--- a/software/core/oqm-core-characteristics/installerSrc/oqm-core-characteristics.service
+++ b/software/core/oqm-core-characteristics/installerSrc/oqm-core-characteristics.service
@@ -21,6 +21,7 @@ Environment="ENV_CONFIG_TEMPLATE=/etc/oqm/serviceConfig/core/characteristics/cor
 Environment="ENV_CONFIG_FILE=/tmp/oqm/serviceConfig/core/characteristics/env.list"
 Environment="USER_CONFIG_TEMPLATE=/etc/oqm/serviceConfig/core/characteristics/user-config.list"
 Environment="USER_CONFIG_FILE=/tmp/oqm/serviceConfig/core/characteristics/user.list"
+Environment="MEMORY_LIMIT=$(oqm-captain u calcRamLimit)"
 
 ExecStartPre=/bin/bash -c "oqm-captain container ensure-setup"
 
@@ -47,7 +48,7 @@ ExecStart=/bin/bash -c "/usr/bin/docker run \
                                  -v /etc/oqm/static/media/:/data/oqm/media:ro \
                                  --env-file $ENV_CONFIG_FILE \
                                  --env-file $USER_CONFIG_FILE \
-                                 --memory 512M \
+                                 --memory \"$(oqm-captain u calcRamLimit --min core.characteristics.resourceLimits.mem.min --max core.characteristics.resourceLimits.mem.max)\" \
                                  $IMAGE_NAME:$IMAGE_VERSION"
 # ensure up, healthy
 ExecStartPost=/bin/bash -c "running=\"false\"; \


### PR DESCRIPTION
Checklist:

 - [ ] Tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable RAM limit profiles for services, including SLIM and PERFORMANCE options.
  * Added a command-line utility to calculate service memory limits using host resources and configured minimum and maximum bounds.
  * Service deployments now apply dynamically calculated memory limits instead of a fixed limit.
  * Added visibility into the number of available OQM services.

* **Configuration**
  * Set the default Station-Captain RAM profile to SLIM.
  * Added core characteristics memory limits of 0.05–0.512 GB.

* **Chores**
  * Updated the Station-Captain version to 2.13.0-SNAPSHOT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->